### PR TITLE
Release requires an empty JSON body

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -97,7 +97,7 @@ Queue.prototype.touch = function(id, fn) {
 };
 
 Queue.prototype.release = function(id, fn) {
-  this.api.post(join(this.path, 'messages', id, 'release'), null, fn);
+  this.api.post(join(this.path, 'messages', id, 'release'), {}, fn);
 };
 
 // push queue endpoints


### PR DESCRIPTION
When releasing a message, at the minimum an empty JSON body must be sent. {}
according to: http://dev.iron.io/mq/reference/api/#release_a_message_on_a_queue
