### PR TITLE
Do not use path.join for URLs, as Windows would introduce backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
 var Cache = require('./lib/cache')
   , Queue = require('./lib/queue')
   , task = require('./lib/task')
-  , join = require('path').join
   , querystring = require('querystring')
   ;
 
@@ -21,7 +20,7 @@ function ironio(token, options) {
   var path = 'projects';
 
   function projects(id) {
-    var projectPath = join(path, id);
+    var projectPath = path + '/' +  id;
 
     function createListFn(name) {
       return function(params, fn) {
@@ -30,7 +29,7 @@ function ironio(token, options) {
           params = null;
         }
         
-        var servicePath = join(projectPath, name) +
+        var servicePath = projectPath + '/' + name +
           (params ? '?' + querystring.stringify(params) : '');
          
         api.get(servicePath, fn);
@@ -40,7 +39,7 @@ function ironio(token, options) {
     function createService(type) {
       var name = type.name.toLowerCase() + 's';
       function service(id) {
-        return new type(join(projectPath, name, id), api);
+        return new type(projectPath + '/' + name + '/' + id, api);
       }
       service.list = createListFn(name);
       return service;
@@ -48,7 +47,7 @@ function ironio(token, options) {
 
     // 'tasks' needs some specialization
     // to make the API nicer
-    var tasks = task(join(projectPath, 'tasks'), api);
+    var tasks = task(projectPath + '/' + 'tasks', api);
     tasks.list = createListFn('tasks');
     tasks.scheduled.list = createListFn('schedules');
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,9 +1,7 @@
 /*!
  * Module dependencies.
  */
-var request = require('request')
-  , path = require('path')
-  ;
+var request = require('request');
 
 /**
  * @constant
@@ -39,8 +37,8 @@ function api(token, options) {
     }
     var subdomain = CLOUDS[cloud][service];
     var version = service === 'worker' ? '2' : '1';
-    var url = 'https://' + subdomain + '.iron.io/' + 
-      path.join(version, endpoint);
+    var url = 'https://' + subdomain + '.iron.io/' +
+      version + '/' +  endpoint;
       
     var requestOptions = {
         url: url 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,7 +1,6 @@
 /*!
  * Module dependencies.
  */
-var join = require('path').join;
 
 function Cache(path, api) {
   this.path = path;
@@ -17,23 +16,23 @@ Cache.prototype.destroy = function(fn) {
 };
 
 Cache.prototype.clear = function(fn) {
-  this.api.post(join(this.path, 'clear'), null, fn);
+  this.api.post(this.path + '/clear', null, fn);
 };
 
 Cache.prototype.put = function(key, value, fn) {
   if (typeof value === 'string') {
     value = { value: value };
   }
-  this.api.put(join(this.path, 'items', key), value, fn);
+  this.api.put(this.path + '/items/' + key, value, fn);
 };
 
 Cache.prototype.incr = function(key, amount, fn) {
   var body = { amount: amount };
-  this.api.post(join(this.path, 'items', key, 'increment'), body, fn);
+  this.api.post(this.path + '/items/' + key + '/increment', body, fn);
 };
   
 Cache.prototype.get = function(key, fn) {
-  this.api.get(join(this.path, 'items', key), function(err, res) {
+  this.api.get(this.path + '/items/'+ key, function(err, res) {
     if (err) {
       // this doesn't seem elegant, but a non-existent key 
       // is not an error for a lot of cases (key expired, deleted, etc.)
@@ -47,7 +46,7 @@ Cache.prototype.get = function(key, fn) {
 };
 
 Cache.prototype.del = function(key, fn) {
-  this.api.del(join(this.path, 'items', key), fn);
+  this.api.del(this.path + '/items/' + key, fn);
 };
 
 /*!

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,9 +1,7 @@
 /*!
  * Module dependencies.
  */
-var join = require('path').join
-  , querystring = require('querystring')
-  ;
+var querystring = require('querystring');
 
 function Queue(path, api) {
   this.path = path;
@@ -23,7 +21,7 @@ Queue.prototype.destroy = function(fn) {
 };
 
 Queue.prototype.clear = function(fn) {
-  this.api.post(join(this.path, 'clear'), null, fn);
+  this.api.post(this.path + '/clear', null, fn);
 };
 
 Queue.prototype.post = function(messages, fn) {
@@ -34,11 +32,11 @@ Queue.prototype.post = function(messages, fn) {
     messages = [messages];
   }
   var body = { messages: messages };
-  this.api.post(join(this.path, 'messages'), body, fn);
+  this.api.post(this.path + '/messages', body, fn);
 };
 
 Queue.prototype.get = function(params, fn) {
-  var msgPath = join(this.path, 'messages');
+  var msgPath = this.path +  '/messages';
 
   if (typeof params === 'function') {
     fn = params;
@@ -72,11 +70,11 @@ Queue.prototype.get = function(params, fn) {
 };
 
 Queue.prototype.del = function(id, fn) {
-  this.api.del(join(this.path, 'messages', id), fn);
+  this.api.del(this.path + '/messages/' + id, fn);
 };
 
 Queue.prototype.peek = function(n, fn) {
-  var peekPath = join(this.path, 'messages', 'peek');
+  var peekPath = this.path + '/messages/peek';
 
   if (typeof n === 'function') {
     fn = n;
@@ -93,7 +91,7 @@ Queue.prototype.peek = function(n, fn) {
 };
 
 Queue.prototype.touch = function(id, fn) {
-  this.api.post(join(this.path, 'messages', id, 'touch'), {}, fn);
+  this.api.post(this.path + '/messages/' + id + '/touch', {}, fn);
 };
 
 Queue.prototype.release = function(id, delay, fn) {
@@ -102,12 +100,12 @@ Queue.prototype.release = function(id, delay, fn) {
     delay = 0;
   }
   var body = { delay: delay };
-  this.api.post(join(this.path, 'messages', id, 'release'), body, fn);
+  this.api.post(this.path + '/messages/' + id + '/release', body, fn);
 };
 
 // push queue endpoints
 Queue.prototype.subscribe = function(subscribers, fn) {
-  var subscribePath = join(this.path, 'subscribers');
+  var subscribePath = this.path + '/subscribers';
   if (Array.isArray(subscribers)) {
     subscribers = subscribers.map(function(s) {
       return { url: s };
@@ -120,7 +118,7 @@ Queue.prototype.subscribe = function(subscribers, fn) {
 };
 
 Queue.prototype.unsubscribe = function(subscribers, fn) {
-  var subscribePath = join(this.path, 'subscribers');
+  var subscribePath = this.path + '/subscribers';
   if (Array.isArray(subscribers)) {
     subscribers = subscribers.map(function(s) {
       return { url: s };
@@ -133,7 +131,7 @@ Queue.prototype.unsubscribe = function(subscribers, fn) {
 };
 
 Queue.prototype.subscribers = function(messageId, fn) {
-  var msgPath = join(this.path, 'messages', messageId, 'subscribers');
+  var msgPath = this.path + '/messages/' + messageId + '/subscribers';
   this.api.get(msgPath, fn);
 };
 

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,7 +1,16 @@
 /*!
  * Module dependencies.
  */
-var join = require('path').join;
+function join() {
+    var result = '';
+    if (arguments.length >= 1) {
+        result = arguments[0];
+        for (var i = 1; i < arguments.length; i++) {
+            result = result + '/' + arguments[i];
+        }
+    }
+    return result;
+}
 
 function task(path, api) {
   var taskPath = path;


### PR DESCRIPTION
...roducing backslashes where we don't want to have them. Two variants provided: Simple string concatenation, and in task.js the implementation of a replacement join() function. Which do you like better?
