### PR TITLE
introduced noop in message callbacks.

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -50,13 +50,13 @@ Queue.prototype.get = function(params, fn) {
     var messages = body.messages.map(function(message) {
       // convenience
       message.del = function(fn) {
-        self.del(this.id, fn);
+        self.del(this.id, fn || noop);
       };
       message.touch = function(fn) {
-        self.touch(this.id, fn);
+        self.touch(this.id, fn || noop);
       };
       message.release = function(fn) {
-        self.release(this.id, fn);
+        self.release(this.id, fn || noop);
       };
       return message;
     });
@@ -134,6 +134,9 @@ Queue.prototype.subscribers = function(messageId, fn) {
   var msgPath = this.path + '/messages/' + messageId + '/subscribers';
   this.api.get(msgPath, fn);
 };
+
+// helpers
+function noop() {}
 
 /*!
  * Module exports.


### PR DESCRIPTION
This is just a cosmetic change so the callback in message could be avoided:

``` js
// Get a message
q.get(function(err, message) {
  // do something with the message
  // then delete it
  message.del();

  // need more time?
  // touch the message
  message.touch();

  // can't process the message
  // release the message
  message.release();
});


```
